### PR TITLE
Set up a test page

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+semi: true
+singleQuote: true
+tabWidth: 2
+printWidth: 100

--- a/layout/azavea-test/index.jsx
+++ b/layout/azavea-test/index.jsx
@@ -1,0 +1,43 @@
+import AppLayout from 'layout/layout/layout-app';
+
+import PropTypes from 'prop-types';
+
+// Most other Layouts in this project seem to be thin wrappers for wiring up props (e.g. for
+// authentication info), and the actual JSX is inside a separate component.  Currently this Layout
+// doesn't rely on any external information, so there are no props to wire up, and our style tends
+// to keep wiring and the actual component together in the same file anyway, so I've leaned toward
+// Azavea style rather than project style in this case.
+export default function AzaveaTestLayout({ children }) {
+  return (
+    <AppLayout
+      title="Test Page"
+      description="A simple test page to help understand how this project works"
+    >
+      {/* This might be good to pull out into a separate component when we do this "for real"; it
+      seems to be repeated with minor variations in several places. */}
+      <header className="l-page-header">
+        <div className="l-container">
+          <div className="row">
+            <div className="column small-12">
+              <div className="page-header-content">
+                <h1>Azavea Test Page</h1>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+      <section className="l-section -secondary">
+        <p>
+          This is a test page. It was created using a single Page, a single Layout, and no other
+          components.
+        </p>
+        <p>If there is other content nested inside this layout, it will show up here:</p>
+        {children}
+        <p>And this will show up after any child content.</p>
+      </section>
+    </AppLayout>
+  );
+}
+
+// There are linting rules that enforce the presence of this.
+AzaveaTestLayout.propTypes = { children: PropTypes.node.isRequired };

--- a/layout/header/constants.js
+++ b/layout/header/constants.js
@@ -102,6 +102,14 @@ export const APP_HEADER_ITEMS = [
     ],
   },
   {
+    id: 'azavea-test',
+    label: 'Azavea Test',
+    href: '/azavea-test',
+    pages: [
+      '/azavea-test',
+    ],
+  },
+  {
     id: 'search',
     label: 'Search',
   },

--- a/layout/header/header-menu/component.jsx
+++ b/layout/header/header-menu/component.jsx
@@ -40,7 +40,7 @@ const HeaderMenu = () => {
 
           const activeClassName = classnames({ '-active': item.pages && item.pages.includes(pathname) });
           let DropdownMenu;
-          if (item.id !== 'blog') {
+          if (item.id !== 'blog' && item.id !== 'azavea-test') {
             DropdownMenu = dynamic(() => header[item.id]);
           }
 

--- a/pages/azavea-test/index.jsx
+++ b/pages/azavea-test/index.jsx
@@ -1,0 +1,14 @@
+// actions
+// None at the moment
+
+// Layout
+// We could put all our markup straight into this Page, but given that we may end up with multiple
+// sub-pages inside of this page, it seems like the recommended thing to do is to wrap in a Layout.
+// But currently this seems kind of boiler-plateish to me, so if it stays that way after we have
+// some more complex content then we should probably refactor so that this file actually does
+// something useful.
+import AzaveaTestLayout from 'layout/azavea-test';
+
+export default function AzaveaTestPage() {
+  return (<AzaveaTestLayout />);
+}


### PR DESCRIPTION
## Overview

Sets up a test page in order to learn how to do it.
Also adds a `.prettierrc` file so that eslint is easier to comply with if you've got format-on-save enabled in your editor (eslint is run in a pre-commit hook for this project).

## Demo
![Screenshot_2021-07-22_12-59-07](https://user-images.githubusercontent.com/447977/126678795-5c384d73-21b3-4d09-8cf8-c46ba0ddb75f.png)


## Testing instructions
- Load the project
- Confirm that there's a new menu item for "Azavea Test" in the menu bar, and that when you click it you're taken to a new page with some text.
- Confirm that the menu item highlights when you've navigated to the corresponding path.

## Jira task
Closes #2 

## Notes
- I'm targeting this at a new tracking branch called `feature/learning` rather than `develop` because it's not clear that we'll ever want to merge exactly this feature into `develop`, but it seems likely that we'll want to have an easy place for other contributors to refer to it in the future.
- CI is currently failing; I think we might be missing a credential that it needs. We're going to have a coordination meeting with Vizzuality in a couple weeks and I'll bring that up then. But for now I think it's safe to ignore it.

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
