### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature
+about: For tracking implementation of new features
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Overview
+<!-- Brief description of what we want to add or change, and why -->
+
+## Detailed Description
+<!-- Full description of the feature, including specific requirements, acceptance criteria, or stories if possible -->
+
+## Wireframes / Designs
+<!-- If applicable -->
+
+## Other notes
+<!-- Add any further context that doesn't fit well above, e.g.:
+  - Possible implementation strategies
+  - Possible alternatives, contingencies, or incremental solutions, or blockers
+  - Notes on relative priority or factors that could affect future priority
+-->

--- a/.github/ISSUE_TEMPLATE/unexpected.md
+++ b/.github/ISSUE_TEMPLATE/unexpected.md
@@ -1,0 +1,40 @@
+---
+name: Unexpected behavior
+about: Something isn't behaving as expected during testing
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Description
+<!-- Briefly describe what's going wrong. -->
+
+## Steps To Reproduce
+<!-- Steps to reproduce the behavior. Be specific, e.g.
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+-->
+
+## Expected behavior
+<!-- What should happen? -->
+
+## Actual behavior
+<!-- What's happening instead? -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain the problem. -->
+
+## Your environment
+<!-- Relevant details about the environment the bug arose in. -->
+<!-- Edit the list below to leave only the relevant items.
+For issues that don't arise in the front-end, browser and OS aren't necessary.
+For issues that happen across platforms, this whole section might not be necessary. -->
+- Production | Staging | Development
+- Windows | Linux | MacOS
+- Firefox | Chrome | Safari
+
+## Additional context
+<!-- Add any other context about the problem. -->
+<!-- How has this bug affected you? What were you trying to accomplish? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,30 @@
 ## Overview
+
 _Please write a description. If the PR is hard to understand, provide a quick explanation of the code._
 
 ## Testing instructions
-_Please explain how to test the PR: ID of a dataset, steps to reach the feature, etc._
+ * How to test this PR
+ * Prefer bulleted description
+ * Start after checking out this branch
+ * Include any setup required, such as bundling scripts, restarting services, etc.
+ * Include test case, and expected output
 
-## Jira task
-_Provide the link to the task(s), if any._
+## Jira task / Github issue
+_Provide the link to the Jira task(s), if any._
 
----
+Resolves #XXX
+
+### Demo
+
+Optional. Screenshots, `curl` examples, etc.
+
+
+### Notes
+
+Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.
+
 
 ## Checklist before submitting
 - [ ] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
 - [ ] Meaningful commits and code rebased on `develop`.
+- [ ] Add entry to CHANGELOG.md, if appropriate


### PR DESCRIPTION
## Overview

WRI is going to be making issues directly in the repo, so this sets up issue templates for them so that they can give us the information that we need. While I was in there, I also combined the existing PR template with the standard Azavea PR template.

## Testing instructions
I didn't go to the trouble of forking the repo and merging to `develop` to test these because they were mostly copied from existing templates, but if you want to see them live, that'd be the way to do it. Otherwise, simply reading through the templates and checking for clarity and typos should be sufficient.

Resolves #6

---

## Checklist before submitting
- [x] Title: Don't forget to make it clear for everyone, even for people that don't know about the feature/bug.
- [x] Meaningful commits and code rebased on `develop`.
